### PR TITLE
Update runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   comment:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -6,7 +6,7 @@ jobs:
   star-notify:
     if: github.event_name == 'watch'
     name: Notify Slack on star
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Get current star count
       run: |
@@ -20,7 +20,7 @@ jobs:
   good-first-issue-notify:
     if:  github.event_name == 'issues' && github.event.label.name == 'good first issue' || github.event.label.name == 'first-timers-only' 
     name: Notify Slack for new good-first-issue
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Notify slack
         env:


### PR DESCRIPTION
**Description**

Notes for Reviewers

- Towards  https://github.com/meshery/meshery/issues/13754
- Updated the runner image from ubuntu-18.04 to ubuntu-24.04 inside `label-commenter workflow` and `slack.yml`.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will be accelerated and your PR merged more quickly.
-->
